### PR TITLE
TitleBarTab.cs - Make some properties public

### DIFF
--- a/TitleBarTab.cs
+++ b/TitleBarTab.cs
@@ -99,21 +99,21 @@ namespace EasyTabs
 		}
 
 		/// <summary>The area in which the tab is rendered in the client window.</summary>
-		internal Rectangle Area
+		public Rectangle Area
 		{
 			get;
 			set;
 		}
 
 		/// <summary>The area of the close button for this tab in the client window.</summary>
-		internal Rectangle CloseButtonArea
+		public Rectangle CloseButtonArea
 		{
 			get;
 			set;
 		}
 
 		/// <summary>Pre-rendered image of the tab's background.</summary>
-		internal Bitmap TabImage
+		public Bitmap TabImage
 		{
 			get;
 			set;


### PR DESCRIPTION
Some properties (like TabImage, Area etc.) are internal, thus making an override for BaseTabRendere.Render difficult since other programs can't access those properties.
This PR fixed that by making those properties public so other apps (that use EasyTabs) can edit them, thus making process of "creating your own tab renderer" easy.